### PR TITLE
Add imports for provided scope quick fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.0-beta04")
+        classpath("com.android.tools.build:gradle:7.3.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${lintLibs.versions.kotlin.get()}")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.20.0")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.1")
+        classpath("com.android.tools.build:gradle:7.3.0-beta04")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${lintLibs.versions.kotlin.get()}")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.20.0")
     }

--- a/checks/src/main/kotlin/com/faithlife/lint/RedundantCoroutineScopeDetector.kt
+++ b/checks/src/main/kotlin/com/faithlife/lint/RedundantCoroutineScopeDetector.kt
@@ -349,10 +349,11 @@ class RedundantCoroutineScopeDetector : Detector(), SourceCodeScanner {
             "Redundant CoroutineScope",
             """
                 $MESSAGE
-                For LifecycleOwner: `lifecycleScope`
-                For ViewModel: `viewModelScope`
-                For Fragment: Prefer `viewLifecycleOwner.lifecycleScope` over `lifecycleScope`
-                For Views: `findViewTreeLifecycleOwner()?.lifecycleScope`
+
+                - For LifecycleOwner: `lifecycleScope`
+                - For ViewModel: `viewModelScope`
+                - For Fragment: Prefer `viewLifecycleOwner.lifecycleScope` over `lifecycleScope`
+                - For Views: `findViewTreeLifecycleOwner()?.lifecycleScope`
             """,
             moreInfo = "https://developer.android.com/topic/libraries/architecture/coroutines",
             category = Category.CORRECTNESS,

--- a/checks/src/main/kotlin/com/faithlife/lint/SingleApostropheDetector.kt
+++ b/checks/src/main/kotlin/com/faithlife/lint/SingleApostropheDetector.kt
@@ -53,7 +53,7 @@ class SingleApostropheDetector : ResourceXmlDetector() {
 
         val ISSUE = Issue.create(
             "UseUnicodeApostrophe",
-            "Prefer unicode apostrophes.",
+            "Prefer unicode apostrophes",
             "This check enforces the use of unicode punctuation for single quotation uses " +
                 "like possessive parts of speech or contractions.",
             Implementation(SingleApostropheDetector::class.java, Scope.RESOURCE_FILE_SCOPE),

--- a/checks/src/test/kotlin/com/faithlife/lint/RedundantCoroutineScopeDetectorTest.kt
+++ b/checks/src/test/kotlin/com/faithlife/lint/RedundantCoroutineScopeDetectorTest.kt
@@ -618,10 +618,12 @@ class ProfileFragment : AnInterface, CoroutineScopeBase(-123, {}), LifecycleOwne
 
         result.expectFixDiffs(
             """Fix for src/com/faithlife/ProfileFragment.kt line 7: Replace CoroutineScope implementation with viewLifecycleOwner.lifecycleScope:
-@@ -7 +7
+@@ -3 +3
++ import androidx.lifecycle.lifecycleScope
+@@ -7 +8
 - class ProfileFragment : Fragment(), CoroutineScope {
 + class ProfileFragment : Fragment() {
-@@ -10 +10
+@@ -10 +11
 -         launch { }
 +         viewLifecycleOwner.lifecycleScope.launch { }"""
         )
@@ -791,10 +793,12 @@ class ProfileFragment : AnInterface, CoroutineScopeBase(-123, {}), LifecycleOwne
 
         result.expectFixDiffs(
             """Fix for src/com/faithlife/ProfileFragment.kt line 7: Replace CoroutineScope implementation with viewLifecycleOwner.lifecycleScope:
-@@ -7 +7
+@@ -3 +3
++ import androidx.lifecycle.lifecycleScope
+@@ -7 +8
 - class ProfileFragment : Fragment(), CoroutineScope {
 + class ProfileFragment : Fragment() {
-@@ -10 +10
+@@ -10 +11
 -             launch {}
 +             viewLifecycleOwner.lifecycleScope.launch {}"""
         )

--- a/checks/src/test/kotlin/com/faithlife/lint/SingleApostropheDetectorTests.kt
+++ b/checks/src/test/kotlin/com/faithlife/lint/SingleApostropheDetectorTests.kt
@@ -22,7 +22,7 @@ class SingleApostropheDetectorTests : LintDetectorTest() {
         lint().files(xml("res/values/strings.xml", source))
             .run()
             .expect(
-                """res/values/strings.xml:1: Warning: Prefer unicode apostrophes. [UseUnicodeApostrophe]
+                """res/values/strings.xml:1: Warning: Prefer unicode apostrophes [UseUnicodeApostrophe]
                 |<string name="a_bad_string">ASCII's punctuation</string>
                 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 |0 errors, 1 warnings
@@ -36,7 +36,7 @@ class SingleApostropheDetectorTests : LintDetectorTest() {
         lint().files(xml("res/values/strings.xml", source))
             .run()
             .expect(
-                """res/values/strings.xml:1: Warning: Prefer unicode apostrophes. [UseUnicodeApostrophe]
+                """res/values/strings.xml:1: Warning: Prefer unicode apostrophes [UseUnicodeApostrophe]
                 |<string name="a_bad_string">ASCIIs' punctuation</string>
                 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 |0 errors, 1 warnings
@@ -50,7 +50,7 @@ class SingleApostropheDetectorTests : LintDetectorTest() {
         lint().files(xml("res/values/strings.xml", source))
             .run()
             .expect(
-                """res/values/strings.xml:1: Warning: Prefer unicode apostrophes. [UseUnicodeApostrophe]
+                """res/values/strings.xml:1: Warning: Prefer unicode apostrophes [UseUnicodeApostrophe]
                 |<string name="a_bad_string">ASCII\'s punctuation</string>
                 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 |0 errors, 1 warnings

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 val JAVA_VERSION: String by properties
 
 android {
-    compileSdk = 31
+    compileSdk = 32
 
     defaultConfig {
         minSdk = 25
-        targetSdk = 31
+        targetSdk = 32
     }
 
     compileOptions {
@@ -22,6 +22,7 @@ android {
 
     lint {
         warningsAsErrors = true
+        checkDependencies = true
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -23,6 +23,11 @@ android {
     lint {
         warningsAsErrors = true
         checkDependencies = true
+
+        // The pre-release AGP 7.3's lint checks require 33, but the AGP release was only tested
+        // with 32, so that causes another lint error. We should use the most up to date version
+        // when AGP 7.3 stabilizes and remove this supression.
+        disable += "OldTargetApi"
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 val JAVA_VERSION: String by properties
 
 android {
-    compileSdk = 32
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 25
-        targetSdk = 32
+        targetSdk = 33
     }
 
     compileOptions {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -23,11 +23,6 @@ android {
     lint {
         warningsAsErrors = true
         checkDependencies = true
-
-        // The pre-release AGP 7.3's lint checks require 33, but the AGP release was only tested
-        // with 32, so that causes another lint error. We should use the most up to date version
-        // when AGP 7.3 stabilizes and remove this supression.
-        disable += "OldTargetApi"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ dependencyResolutionManagement {
             library("kotlinReflect", "org.jetbrains.kotlin", "kotlin-reflect").versionRef("kotlin")
             bundle("kotlin", listOf("kotlinStd", "kotlinReflect"))
 
-            version("lint", "30.2.1")
+            version("lint", "30.3.0-beta04")
             library("lintApi", "com.android.tools.lint", "lint-api").versionRef("lint")
 
             library("lint", "com.android.tools.lint", "lint").versionRef("lint")


### PR DESCRIPTION
A follow on to #9 that add automatic imports for lifecycle-bound coroutine scope extension properties via the as yet unreleased `imports` method for replacement lint fixes.

We can merge this when AGP 7.3 stabilizes.